### PR TITLE
feat: add wrap daily limit to settings pane

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@safe-global/api-kit": "^3.0.1",
         "@safe-global/protocol-kit": "^6.0.3",
         "@tanstack/react-query": "^5.74.3",
-        "@tari-project/wxtm-bridge-backend-api": "0.1.48",
+        "@tari-project/wxtm-bridge-backend-api": "0.1.49",
         "@tari-project/wxtm-bridge-contracts": "0.1.9",
         "axios": "^1.6.2",
         "connectkit": "^1.9.0",
@@ -4692,9 +4692,9 @@
       }
     },
     "node_modules/@tari-project/wxtm-bridge-backend-api": {
-      "version": "0.1.48",
-      "resolved": "https://registry.npmjs.org/@tari-project/wxtm-bridge-backend-api/-/wxtm-bridge-backend-api-0.1.48.tgz",
-      "integrity": "sha512-1XnVGTeQoen3/gfoju8TWNuLU0qnm+IrbK2EMtZDnMTkt4gr2Mc82wMfzYgzMXRejjrZ/1RTxTT+tjXB7iyWpA==",
+      "version": "0.1.49",
+      "resolved": "https://registry.npmjs.org/@tari-project/wxtm-bridge-backend-api/-/wxtm-bridge-backend-api-0.1.49.tgz",
+      "integrity": "sha512-ikMmV3K8v5eYyExLSEKwDxYlW5o2GYcRKJmWxju9N2BLkc6dBvHkqjpMMXWgZD0ois5OCGFrkHhctI2bnGKdtQ==",
       "license": "ISC"
     },
     "node_modules/@tari-project/wxtm-bridge-contracts": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@safe-global/api-kit": "^3.0.1",
     "@safe-global/protocol-kit": "^6.0.3",
     "@tanstack/react-query": "^5.74.3",
-    "@tari-project/wxtm-bridge-backend-api": "0.1.48",
+    "@tari-project/wxtm-bridge-backend-api": "0.1.49",
     "@tari-project/wxtm-bridge-contracts": "0.1.9",
     "axios": "^1.6.2",
     "connectkit": "^1.9.0",

--- a/src/pages/settings/edit.tsx
+++ b/src/pages/settings/edit.tsx
@@ -53,6 +53,10 @@ export const SettingsEdit = () => {
     return query?.data?.data.unwrapManualApprovalThreshold || '0';
   }, [query]);
 
+  const wrapDailyLimit = useMemo(() => {
+    return query?.data?.data.wrapDailyLimit || '10000000000000000000000000'; // 10_000_000 tokens
+  }, [query]);
+
   return (
     <Edit isLoading={formLoading} saveButtonProps={saveButtonProps} title="Settings">
       <Box sx={{ p: 2 }}>
@@ -231,6 +235,44 @@ export const SettingsEdit = () => {
               fullWidth
               sx={{ maxWidth: 320 }}
               label="Manual Approval Threshold"
+              error={!!fieldState.error}
+              onChange={(e) => {
+                const value = e.target.value;
+                if (value === '' || /^\d+$/.test(value)) {
+                  field.onChange(value === '' ? '' : value + '000000000000000000');
+                }
+              }}
+              slotProps={{
+                htmlInput: {
+                  inputMode: 'numeric',
+                  pattern: '[0-9]*',
+                },
+              }}
+            />
+          )}
+        />
+
+        <Typography variant="h6" sx={{ mb: 2, mt: 2 }}>
+          Wrap limits
+        </Typography>
+
+        <Controller
+          control={control}
+          name="wrapDailyLimit"
+          defaultValue={wrapDailyLimit}
+          rules={{
+            required: 'Daily wrap limit is required',
+            pattern: {
+              value: /^\d+$/,
+              message: 'Must be a valid number',
+            },
+          }}
+          render={({ field, fieldState }) => (
+            <TextField
+              value={field.value ? field.value.slice(0, -18) || '10000000000000000000000000' : ''}
+              fullWidth
+              sx={{ maxWidth: 320 }}
+              label="Daily wrap limit (XTM)"
               error={!!fieldState.error}
               onChange={(e) => {
                 const value = e.target.value;

--- a/src/providers/settings-data-provider.ts
+++ b/src/providers/settings-data-provider.ts
@@ -26,6 +26,7 @@ export const settingsDataProvider: DataProvider = {
       maxBatchAgeMs: number;
       batchAmountThreshold: string;
       unwrapManualApprovalThreshold: string;
+      wrapDailyLimit: string;
     },
   >({
     variables,
@@ -36,6 +37,7 @@ export const settingsDataProvider: DataProvider = {
       maxBatchAgeMs: number;
       batchAmountThreshold: string;
       unwrapManualApprovalThreshold: string;
+      wrapDailyLimit: string;
     };
 
     await SettingsService.updateSettings({
@@ -44,6 +46,7 @@ export const settingsDataProvider: DataProvider = {
       maxBatchAgeMs: typedVars.maxBatchAgeMs,
       batchAmountThreshold: typedVars.batchAmountThreshold,
       unwrapManualApprovalThreshold: typedVars.unwrapManualApprovalThreshold,
+      wrapDailyLimit: typedVars.wrapDailyLimit,
     });
 
     return {


### PR DESCRIPTION
Description
---

Adds wrap daily limit to settings pane.

<img width="1360" height="649" alt="Screenshot 2025-10-29 at 14 49 37" src="https://github.com/user-attachments/assets/18431957-9ead-42bf-8f59-e46b0b3b5b03" />


How Has This Been Tested?
---

Ran locally, but cannot try to save, until it is deployed to staging (local UI connects to AWS staging env)

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
