### PR TITLE
feat: manage Ethereum RPC nodes from the Settings page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,56 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+Admin panel ("tapplet") for the WXTM bridge — the system that wraps Tari (XTM) into wXTM (ERC-20) on Ethereum and unwraps it back. Operators use this UI to review wrap/unwrap transactions, manage bridge settings (service status, batch limits, daily limits), and propose/sign/execute Gnosis Safe multisig transactions that mint wXTM. It's a [Refine](https://refine.dev) + Material UI single-page app built with Vite, deployed as a static site to S3/CloudFront.
+
+## Commands
+
+```bash
+npm run dev        # refine dev server (http://localhost:5173)
+npm run build      # tsc typecheck + refine build → dist/
+npm run typecheck  # tsc --noEmit
+npm run lint       # eslint .
+npm run test       # vitest (jsdom). Append a path or -t "name" for a single test.
+```
+
+Single test: `npm run test -- src/helpers/convert-wxtm-token-to-18-decimals.test.ts`. Tests are `src/**/*.test.ts` only (no component/JSX tests).
+
+CI runs lint → typecheck → test on every PR; all three must pass.
+
+## Environment
+
+Requires a `.env` (see `.env.sample`). `src/config/index.ts` re-exports `VITE_*` vars under clean names. Notable ones beyond Auth0/API: `MINT_LOW_SAFE_ADDRESS` / `MINT_HIGH_SAFE_ADDRESS` (the two Gnosis Safes), `WXTM_TOKEN_ADDRESS`, `NETWORK_ID` (`11155111` = Sepolia for staging, mainnet for prod).
+
+The `@tari-project/wxtm-bridge-backend-api` and `@tari-project/wxtm-bridge-contracts` packages come from a private registry — `npm ci` needs a GitHub token configured (`@tari-project:registry` + `_authToken`), as the CI workflows do.
+
+## Architecture
+
+Refine is configured in `src/App.tsx`, which is the single source of truth for resources, routes, and which data provider serves each resource. Refine's `resources` array maps a resource name → list/edit/show routes + an icon, and `meta.dataProviderName` selects one of the **four** data providers registered on `<Refine dataProvider={{...}}>`. This multi-provider setup is the core architectural pattern — each provider talks to a *different* backend:
+
+- **`default` (`custom-nestjsx-crud-provider.ts`)** — the bridge backend's NestJS CRUD API. Serves `wrap-token-transactions` and `tokens-unwrapped`. Wraps `@refinedev/nestjsx-crud` and rewrites filters in `getList`: maps human-readable status labels (e.g. "Amount Mismatch") to backend enum values, translates the grid's `contains` operator to nestjsx's `cont`, and converts decimal token amounts on `tokenAmount`/`amountAfterFee`/`feeAmount` (6 decimals) into BigInt strings / ranges so amount columns are filterable.
+- **`mintLowSafeDataProvider` / `mintHighSafeDataProvider` (`safe-transactions-data-provider.ts`)** — read-only, backed by the Gnosis Safe Transaction Service via `@safe-global/api-kit`. Same provider factory, instantiated once per Safe address. Only `getList`/`getOne` are implemented; create/update/delete throw.
+- **`settingsDataProvider` (`settings-data-provider.ts`)** — a single settings record via the backend's generated `SettingsService`. Only `getOne`/`update`; the `/settings` page edits service status, batch limits, and wrap/unwrap daily limits.
+
+The Safe data providers are read-only on purpose: **writes go through the connected wallet, not a data provider.** The mint flow lives in hooks under `src/hooks/`, built on `@safe-global/protocol-kit` + wagmi:
+
+- `use-safe.ts` — builds a `Safe` instance and `SafeApiKit` from the wallet connector (`useAccount`).
+- `use-propose-mint-transaction.ts` — encodes `mintLowAmount(to, amount)` on the `WXTMController` contract (ABI from `@tari-project/wxtm-bridge-contracts`), creates + signs the Safe tx, and proposes it.
+- `use-sign-transaction.ts` / `use-execute-transaction.ts` — additional owners confirm; once threshold is met, execute on-chain and wait for the receipt via `@wagmi/core`.
+
+Wallet connectivity (`src/components/wallet-provider/`, `src/config/wagmi-config.ts`) wraps the app in wagmi + ConnectKit + react-query, MetaMask injected connector, chains Sepolia + mainnet.
+
+**Auth** (`src/hooks/use-auth-provider.ts`): Auth0 (`@auth0/auth0-react`) issues the token; `check()` fetches it silently, sets it on both the axios default header and the generated SDK's `OpenAPI.TOKEN`, then calls `UserService.getMe()` and **only authenticates users where `isAdmin` is true** — non-admins are logged out.
+
+## Conventions
+
+- Folder-per-component under `src/components/<name>/` with `index.tsx` + `types.ts` (and sometimes `const.ts`). Pages mirror this under `src/pages/<resource>/`.
+- Edit pages use a tabbed layout (`@mui/lab` TabContext) — e.g. a wrap transaction has Data / Audit / Debug / Aggregated tabs, conditionally shown based on the record.
+- Token amounts are 6-decimal BigInt strings end-to-end; use the `ethers` v5 `utils.parseUnits`/`formatUnits` helpers (see `src/helpers/`) rather than manual math. Contract calldata is decoded via `decode-wxtm-token-calldata.ts`.
+- DataGrid filter operators are restricted per-column via `src/helpers/allowed-operators.ts`.
+
+## Deployment
+
+`main` → auto-deploys to **dev** (S3 `admin.staging-bridge.tari.com`); pushing a **tag** → deploys to **prod** (`admin.bridge.tari.com`). The `Makefile` (`deploy-dev` / `deploy-prod`) runs `npm run build` then `aws s3 sync` + CloudFront invalidation. CI injects env vars by decrypting `env.dev.json` / `env.prod.json` with `sops exec-env`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@auth0/auth0-react": "^1.5.0",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@emotion/react": "^11.8.2",
         "@emotion/styled": "^11.8.1",
         "@microlink/react-json-view": "^1.26.1",
@@ -27,7 +30,7 @@
         "@safe-global/api-kit": "^3.0.1",
         "@safe-global/protocol-kit": "^6.0.3",
         "@tanstack/react-query": "^5.74.3",
-        "@tari-project/wxtm-bridge-backend-api": "0.1.66",
+        "@tari-project/wxtm-bridge-backend-api": "0.1.68",
         "@tari-project/wxtm-bridge-contracts": "0.1.9",
         "axios": "^1.6.2",
         "connectkit": "^1.9.0",
@@ -902,6 +905,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@ecies/ciphers": {
@@ -4692,9 +4748,9 @@
       }
     },
     "node_modules/@tari-project/wxtm-bridge-backend-api": {
-      "version": "0.1.66",
-      "resolved": "https://registry.npmjs.org/@tari-project/wxtm-bridge-backend-api/-/wxtm-bridge-backend-api-0.1.66.tgz",
-      "integrity": "sha512-D1gF4dhmy5caA5SCO79PSb/uTjYfxf56Lk15AynlKXQocxp0Q112IXfHLibjoAwkiYqJWz6pY0F1e+K3WmGFVQ==",
+      "version": "0.1.68",
+      "resolved": "https://registry.npmjs.org/@tari-project/wxtm-bridge-backend-api/-/wxtm-bridge-backend-api-0.1.68.tgz",
+      "integrity": "sha512-Pk8AACZOlNRsS1vIOJHLPGBtQD2UjCztPxEzPYE5BB82Xwf/n/DnG7XHkdTmxlFcUfzx/xWJlArS7IMKmZyh4A==",
       "license": "ISC"
     },
     "node_modules/@tari-project/wxtm-bridge-contracts": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "type": "module",
   "dependencies": {
     "@auth0/auth0-react": "^1.5.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@emotion/react": "^11.8.2",
     "@emotion/styled": "^11.8.1",
     "@microlink/react-json-view": "^1.26.1",
@@ -23,7 +26,7 @@
     "@safe-global/api-kit": "^3.0.1",
     "@safe-global/protocol-kit": "^6.0.3",
     "@tanstack/react-query": "^5.74.3",
-    "@tari-project/wxtm-bridge-backend-api": "0.1.66",
+    "@tari-project/wxtm-bridge-backend-api": "0.1.68",
     "@tari-project/wxtm-bridge-contracts": "0.1.9",
     "axios": "^1.6.2",
     "connectkit": "^1.9.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,7 @@ import { TokensUnwrappedEdit } from './pages/tokens-unwrapped/edit';
 import { customNestjsxCrudDataProvider } from './providers/custom-nestjsx-crud-provider';
 import { SettingsEdit } from './pages/settings';
 import { settingsDataProvider } from './providers/settings-data-provider';
+import { ethereumNodesDataProvider } from './providers/ethereum-nodes-data-provider';
 
 function App() {
   const dataProvider = customNestjsxCrudDataProvider(API_URL, axios);
@@ -77,6 +78,7 @@ function App() {
                     mintLowSafeDataProvider,
                     mintHighSafeDataProvider,
                     settingsDataProvider,
+                    ethereumNodesDataProvider,
                   }}
                   notificationProvider={useNotificationProvider}
                   routerProvider={routerBindings}

--- a/src/components/ethereum-nodes-manager/chain-group.tsx
+++ b/src/components/ethereum-nodes-manager/chain-group.tsx
@@ -1,0 +1,132 @@
+import {
+  DndContext,
+  DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { Box, Button, Chip, Stack, Typography } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+
+import { NodeRow } from './node-row';
+import { ChainGroupProps } from './types';
+
+/**
+ * One chain's worth of RPC nodes. Drag-and-drop is scoped to this context, so a
+ * node can only be reordered within its own chain. On drop we hand the new id
+ * order up to the parent, which persists the resulting `sortOrder` values.
+ */
+export const ChainGroup = ({
+  chainId,
+  label,
+  caption,
+  color,
+  nodes,
+  onReorder,
+  onToggleEnabled,
+  onEdit,
+  onDelete,
+  onAdd,
+}: ChainGroupProps) => {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) {
+      return;
+    }
+    const oldIndex = nodes.findIndex((n) => n.id === active.id);
+    const newIndex = nodes.findIndex((n) => n.id === over.id);
+    if (oldIndex === -1 || newIndex === -1) {
+      return;
+    }
+    const orderedIds = arrayMove(nodes, oldIndex, newIndex).map((n) => n.id);
+    onReorder(chainId, orderedIds);
+  };
+
+  return (
+    <Box sx={{ mb: 3 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          mb: 1.5,
+          gap: 2,
+          flexWrap: 'wrap',
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+          <Box sx={{ width: 12, height: 12, borderRadius: '50%', bgcolor: color, flexShrink: 0 }} />
+          <Box>
+            <Typography variant="subtitle1" sx={{ fontWeight: 600, lineHeight: 1.2 }}>
+              {label}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              {caption}
+            </Typography>
+          </Box>
+          <Chip
+            size="small"
+            variant="outlined"
+            label={`${nodes.length} node${nodes.length === 1 ? '' : 's'}`}
+          />
+        </Box>
+
+        <Button
+          size="small"
+          variant="outlined"
+          startIcon={<AddIcon />}
+          onClick={() => onAdd(chainId)}
+        >
+          Add node
+        </Button>
+      </Box>
+
+      {nodes.length === 0 ? (
+        <Box
+          sx={{
+            px: 2,
+            py: 2.5,
+            borderRadius: 1,
+            border: '1px dashed',
+            borderColor: 'divider',
+            textAlign: 'center',
+          }}
+        >
+          <Typography variant="body2" color="text.secondary">
+            No nodes configured — the frontend will fall back to viem's public RPCs for this chain.
+          </Typography>
+        </Box>
+      ) : (
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext items={nodes.map((n) => n.id)} strategy={verticalListSortingStrategy}>
+            <Stack spacing={1}>
+              {nodes.map((node, index) => (
+                <NodeRow
+                  key={node.id}
+                  node={node}
+                  position={index + 1}
+                  onToggleEnabled={onToggleEnabled}
+                  onEdit={onEdit}
+                  onDelete={onDelete}
+                />
+              ))}
+            </Stack>
+          </SortableContext>
+        </DndContext>
+      )}
+    </Box>
+  );
+};

--- a/src/components/ethereum-nodes-manager/chain-group.tsx
+++ b/src/components/ethereum-nodes-manager/chain-group.tsx
@@ -35,6 +35,7 @@ export const ChainGroup = ({
   onEdit,
   onDelete,
   onAdd,
+  disabled,
 }: ChainGroupProps) => {
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
@@ -89,6 +90,7 @@ export const ChainGroup = ({
           variant="outlined"
           startIcon={<AddIcon />}
           onClick={() => onAdd(chainId)}
+          disabled={disabled}
         >
           Add node
         </Button>
@@ -121,6 +123,7 @@ export const ChainGroup = ({
                   onToggleEnabled={onToggleEnabled}
                   onEdit={onEdit}
                   onDelete={onDelete}
+                  disabled={disabled}
                 />
               ))}
             </Stack>

--- a/src/components/ethereum-nodes-manager/const.ts
+++ b/src/components/ethereum-nodes-manager/const.ts
@@ -1,0 +1,15 @@
+import { ChainMeta } from './types';
+
+/**
+ * The chains the backend accepts (`SUPPORTED_CHAIN_IDS` in
+ * `ethereum-node.const.ts`). Rendered in this order, always shown even when a
+ * chain has no nodes yet.
+ */
+export const SUPPORTED_CHAINS: ChainMeta[] = [
+  { id: 1, label: 'Ethereum Mainnet', caption: 'chainId 1', color: '#627EEA' },
+  { id: 11155111, label: 'Sepolia', caption: 'chainId 11155111 · testnet', color: '#CFB53B' },
+  { id: 84532, label: 'Base Sepolia', caption: 'chainId 84532 · testnet', color: '#0052FF' },
+];
+
+/** Matches the backend's `@IsUrl({ protocols: ['http','https'], require_protocol: true })`. */
+export const HTTP_URL_PATTERN = /^https?:\/\/.+/i;

--- a/src/components/ethereum-nodes-manager/health-chip.tsx
+++ b/src/components/ethereum-nodes-manager/health-chip.tsx
@@ -1,0 +1,61 @@
+import { useMemo } from 'react';
+import { Chip, ChipProps, Tooltip, Box, Typography } from '@mui/material';
+import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord';
+
+import { EthereumNodeEntity } from '@tari-project/wxtm-bridge-backend-api';
+
+import { DateFormatedField } from '../date-formated-field';
+import { HealthChipProps } from './types';
+
+const STATUS_META: Record<
+  EthereumNodeEntity.status,
+  { label: string; color: ChipProps['color']; dot: string }
+> = {
+  [EthereumNodeEntity.status.UP]: { label: 'Up', color: 'success', dot: 'success.main' },
+  [EthereumNodeEntity.status.DOWN]: { label: 'Down', color: 'error', dot: 'error.main' },
+  [EthereumNodeEntity.status.UNKNOWN]: {
+    label: 'Unknown',
+    color: 'default',
+    dot: 'text.disabled',
+  },
+};
+
+/**
+ * Read-only health semaphore driven by the monitor lambda's fields. The chip
+ * colour reflects `status`; the tooltip surfaces when it was last probed and,
+ * for a down node, how long it has been failing.
+ */
+export const HealthChip = ({ status, lastCheckedAt, downSince }: HealthChipProps) => {
+  const meta = useMemo(
+    () => STATUS_META[status] ?? STATUS_META[EthereumNodeEntity.status.UNKNOWN],
+    [status]
+  );
+
+  const tooltip = (
+    <Box sx={{ p: 0.5 }}>
+      <Typography variant="caption" component="div" sx={{ display: 'flex', gap: 0.5 }}>
+        <span>Last checked:</span>
+        {lastCheckedAt ? <DateFormatedField date={lastCheckedAt} /> : <span>never</span>}
+      </Typography>
+      {status === EthereumNodeEntity.status.DOWN && downSince && (
+        <Typography variant="caption" component="div" sx={{ display: 'flex', gap: 0.5 }}>
+          <span>Down since:</span>
+          <DateFormatedField date={downSince} />
+        </Typography>
+      )}
+    </Box>
+  );
+
+  return (
+    <Tooltip arrow title={tooltip}>
+      <Chip
+        size="small"
+        variant="outlined"
+        color={meta.color}
+        icon={<FiberManualRecordIcon sx={{ fontSize: 12, color: meta.dot }} />}
+        label={meta.label}
+        sx={{ minWidth: 92, '& .MuiChip-icon': { ml: 1 } }}
+      />
+    </Tooltip>
+  );
+};

--- a/src/components/ethereum-nodes-manager/index.tsx
+++ b/src/components/ethereum-nodes-manager/index.tsx
@@ -113,6 +113,8 @@ export const EthereumNodesManager = () => {
           })
         )
       );
+    } catch (error) {
+      console.error('Failed to reorder ethereum nodes:', error);
     } finally {
       setSaving(false);
       revalidate();

--- a/src/components/ethereum-nodes-manager/index.tsx
+++ b/src/components/ethereum-nodes-manager/index.tsx
@@ -239,7 +239,10 @@ export const EthereumNodesManager = () => {
         onSubmit={handleSubmit}
       />
 
-      <Dialog open={deleteTarget !== null} onClose={() => setDeleteTarget(null)}>
+      <Dialog
+        open={deleteTarget !== null}
+        onClose={saving ? undefined : () => setDeleteTarget(null)}
+      >
         <DialogTitle>Delete RPC node?</DialogTitle>
         <DialogContent>
           <DialogContentText sx={{ wordBreak: 'break-all' }}>

--- a/src/components/ethereum-nodes-manager/index.tsx
+++ b/src/components/ethereum-nodes-manager/index.tsx
@@ -48,7 +48,7 @@ export const EthereumNodesManager = () => {
   });
 
   const { mutate: createNode } = useCreate();
-  const { mutate: updateNode } = useUpdate();
+  const { mutate: updateNode, mutateAsync: updateNodeAsync } = useUpdate();
   const { mutate: deleteNode } = useDelete();
 
   // Local mirror of the server list so drag-reorder / toggles feel instant; it
@@ -84,7 +84,7 @@ export const EthereumNodesManager = () => {
   const revalidate = () =>
     invalidate({ resource: RESOURCE, dataProviderName: DATA_PROVIDER, invalidates: ['list'] });
 
-  const handleReorder = (chainId: number, orderedIds: number[]) => {
+  const handleReorder = async (chainId: number, orderedIds: number[]) => {
     const byId = new Map(nodes.map((n) => [n.id, n]));
     const reordered = orderedIds
       .map((id) => byId.get(id))
@@ -97,32 +97,31 @@ export const EthereumNodesManager = () => {
     if (changed.length === 0) {
       return;
     }
-    let remaining = changed.length;
-    changed.forEach((node) => {
-      updateNode(
-        {
-          resource: RESOURCE,
-          dataProviderName: DATA_PROVIDER,
-          id: node.id,
-          values: { sortOrder: node.sortOrder },
-          successNotification: false,
-          mutationMode: 'pessimistic',
-          invalidates: [],
-        },
-        {
-          onSettled: () => {
-            remaining -= 1;
-            if (remaining === 0) {
-              revalidate();
-            }
-          },
-        }
+
+    setSaving(true);
+    try {
+      await Promise.all(
+        changed.map((node) =>
+          updateNodeAsync({
+            resource: RESOURCE,
+            dataProviderName: DATA_PROVIDER,
+            id: node.id,
+            values: { sortOrder: node.sortOrder },
+            successNotification: false,
+            mutationMode: 'pessimistic',
+            invalidates: [],
+          })
+        )
       );
-    });
+    } finally {
+      setSaving(false);
+      revalidate();
+    }
   };
 
   const handleToggleEnabled = (node: EthereumNodeEntity, enabled: boolean) => {
     setNodes((prev) => prev.map((n) => (n.id === node.id ? { ...n, enabled } : n)));
+    setSaving(true);
     updateNode(
       {
         resource: RESOURCE,
@@ -133,7 +132,16 @@ export const EthereumNodesManager = () => {
         mutationMode: 'pessimistic',
         invalidates: [],
       },
-      { onSuccess: revalidate, onError: revalidate }
+      {
+        onSuccess: () => {
+          setSaving(false);
+          revalidate();
+        },
+        onError: () => {
+          setSaving(false);
+          revalidate();
+        },
+      }
     );
   };
 

--- a/src/components/ethereum-nodes-manager/index.tsx
+++ b/src/components/ethereum-nodes-manager/index.tsx
@@ -224,6 +224,7 @@ export const EthereumNodesManager = () => {
               onEdit={(node) => setForm({ open: true, chainId: node.chainId, node })}
               onDelete={(node) => setDeleteTarget(node)}
               onAdd={(chainId) => setForm({ open: true, chainId, node: null })}
+              disabled={saving}
             />
           </Box>
         ))

--- a/src/components/ethereum-nodes-manager/index.tsx
+++ b/src/components/ethereum-nodes-manager/index.tsx
@@ -75,6 +75,9 @@ export const EthereumNodesManager = () => {
         bucket.push(node);
       }
     }
+    for (const bucket of map.values()) {
+      bucket.sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0));
+    }
     return map;
   }, [nodes]);
 

--- a/src/components/ethereum-nodes-manager/index.tsx
+++ b/src/components/ethereum-nodes-manager/index.tsx
@@ -1,0 +1,249 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useCreate, useDelete, useInvalidate, useList, useUpdate } from '@refinedev/core';
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Divider,
+  Paper,
+  Typography,
+} from '@mui/material';
+
+import { EthereumNodeEntity } from '@tari-project/wxtm-bridge-backend-api';
+
+import { ChainGroup } from './chain-group';
+import { NodeFormDialog } from './node-form-dialog';
+import { SUPPORTED_CHAINS } from './const';
+
+const RESOURCE = 'ethereum-nodes';
+const DATA_PROVIDER = 'ethereumNodesDataProvider';
+
+interface FormState {
+  open: boolean;
+  chainId: number;
+  node: EthereumNodeEntity | null;
+}
+
+/**
+ * Self-contained CRUD section for the bridge's public Ethereum RPC nodes,
+ * embedded at the bottom of the Settings page. Every action (add / edit /
+ * toggle / reorder / delete) persists immediately via its own mutations and is
+ * independent of the Settings form's Save button.
+ *
+ * Nodes are grouped by chain and ordered by priority — the first enabled node
+ * is the frontend's primary RPC, the rest are viem `fallback()` endpoints.
+ */
+export const EthereumNodesManager = () => {
+  const invalidate = useInvalidate();
+
+  const { data, isLoading } = useList<EthereumNodeEntity>({
+    resource: RESOURCE,
+    dataProviderName: DATA_PROVIDER,
+    pagination: { mode: 'off' },
+  });
+
+  const { mutate: createNode } = useCreate();
+  const { mutate: updateNode } = useUpdate();
+  const { mutate: deleteNode } = useDelete();
+
+  // Local mirror of the server list so drag-reorder / toggles feel instant; it
+  // resyncs whenever the query refetches after a mutation invalidation.
+  const [nodes, setNodes] = useState<EthereumNodeEntity[]>([]);
+  useEffect(() => {
+    if (data?.data) {
+      setNodes(data.data);
+    }
+  }, [data]);
+
+  const [form, setForm] = useState<FormState>({ open: false, chainId: 1, node: null });
+  const [deleteTarget, setDeleteTarget] = useState<EthereumNodeEntity | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const nodesByChain = useMemo(() => {
+    const map = new Map<number, EthereumNodeEntity[]>();
+    for (const chain of SUPPORTED_CHAINS) {
+      map.set(chain.id, []);
+    }
+    for (const node of nodes) {
+      const bucket = map.get(node.chainId);
+      if (bucket) {
+        bucket.push(node);
+      }
+    }
+    return map;
+  }, [nodes]);
+
+  const revalidate = () =>
+    invalidate({ resource: RESOURCE, dataProviderName: DATA_PROVIDER, invalidates: ['list'] });
+
+  const handleReorder = (chainId: number, orderedIds: number[]) => {
+    const byId = new Map(nodes.map((n) => [n.id, n]));
+    const reordered = orderedIds
+      .map((id) => byId.get(id))
+      .filter((n): n is EthereumNodeEntity => n !== undefined)
+      .map((n, index) => ({ ...n, sortOrder: index }));
+    const others = nodes.filter((n) => n.chainId !== chainId);
+    setNodes([...others, ...reordered]);
+
+    const changed = reordered.filter((n) => byId.get(n.id)?.sortOrder !== n.sortOrder);
+    if (changed.length === 0) {
+      return;
+    }
+    let remaining = changed.length;
+    changed.forEach((node) => {
+      updateNode(
+        {
+          resource: RESOURCE,
+          dataProviderName: DATA_PROVIDER,
+          id: node.id,
+          values: { sortOrder: node.sortOrder },
+          successNotification: false,
+          mutationMode: 'pessimistic',
+          invalidates: [],
+        },
+        {
+          onSettled: () => {
+            remaining -= 1;
+            if (remaining === 0) {
+              revalidate();
+            }
+          },
+        }
+      );
+    });
+  };
+
+  const handleToggleEnabled = (node: EthereumNodeEntity, enabled: boolean) => {
+    setNodes((prev) => prev.map((n) => (n.id === node.id ? { ...n, enabled } : n)));
+    updateNode(
+      {
+        resource: RESOURCE,
+        dataProviderName: DATA_PROVIDER,
+        id: node.id,
+        values: { enabled },
+        successNotification: false,
+        mutationMode: 'pessimistic',
+        invalidates: [],
+      },
+      { onSuccess: revalidate, onError: revalidate }
+    );
+  };
+
+  const handleSubmit = (values: { chainId: number; url: string; enabled: boolean }) => {
+    setSaving(true);
+    const onSuccess = () => {
+      setSaving(false);
+      setForm({ open: false, chainId: values.chainId, node: null });
+    };
+    const onError = () => setSaving(false);
+
+    if (form.node) {
+      updateNode(
+        { resource: RESOURCE, dataProviderName: DATA_PROVIDER, id: form.node.id, values },
+        { onSuccess, onError }
+      );
+    } else {
+      createNode(
+        { resource: RESOURCE, dataProviderName: DATA_PROVIDER, values },
+        { onSuccess, onError }
+      );
+    }
+  };
+
+  const handleDeleteConfirm = () => {
+    if (!deleteTarget) {
+      return;
+    }
+    setSaving(true);
+    deleteNode(
+      { resource: RESOURCE, dataProviderName: DATA_PROVIDER, id: deleteTarget.id },
+      {
+        onSuccess: () => {
+          setSaving(false);
+          setDeleteTarget(null);
+        },
+        onError: () => setSaving(false),
+      }
+    );
+  };
+
+  return (
+    <Paper elevation={2} sx={{ mb: 4, p: 3 }}>
+      <Typography
+        variant="h5"
+        component="h2"
+        sx={{
+          mb: 0.5,
+          fontWeight: 'bold',
+          color: 'info.main',
+          borderBottom: '2px solid',
+          borderColor: 'info.main',
+          pb: 1,
+        }}
+      >
+        Ethereum RPC Nodes
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+        Public RPC endpoints served to the frontend, per chain. Drag to set priority — the first
+        enabled node is the primary RPC and the rest act as fallbacks. Changes here save
+        immediately.
+      </Typography>
+
+      {isLoading && nodes.length === 0 ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+          <CircularProgress />
+        </Box>
+      ) : (
+        SUPPORTED_CHAINS.map((chain, index) => (
+          <Box key={chain.id}>
+            {index > 0 && <Divider sx={{ mb: 3 }} />}
+            <ChainGroup
+              chainId={chain.id}
+              label={chain.label}
+              caption={chain.caption}
+              color={chain.color}
+              nodes={nodesByChain.get(chain.id) ?? []}
+              onReorder={handleReorder}
+              onToggleEnabled={handleToggleEnabled}
+              onEdit={(node) => setForm({ open: true, chainId: node.chainId, node })}
+              onDelete={(node) => setDeleteTarget(node)}
+              onAdd={(chainId) => setForm({ open: true, chainId, node: null })}
+            />
+          </Box>
+        ))
+      )}
+
+      <NodeFormDialog
+        open={form.open}
+        chainId={form.chainId}
+        node={form.node}
+        saving={saving}
+        onClose={() => setForm((prev) => ({ ...prev, open: false }))}
+        onSubmit={handleSubmit}
+      />
+
+      <Dialog open={deleteTarget !== null} onClose={() => setDeleteTarget(null)}>
+        <DialogTitle>Delete RPC node?</DialogTitle>
+        <DialogContent>
+          <DialogContentText sx={{ wordBreak: 'break-all' }}>
+            {deleteTarget?.url} will be removed and no longer served to the frontend. This cannot be
+            undone.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={() => setDeleteTarget(null)} disabled={saving}>
+            Cancel
+          </Button>
+          <Button color="error" variant="contained" onClick={handleDeleteConfirm} disabled={saving}>
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Paper>
+  );
+};

--- a/src/components/ethereum-nodes-manager/node-form-dialog.tsx
+++ b/src/components/ethereum-nodes-manager/node-form-dialog.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useState } from 'react';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  Switch,
+  TextField,
+} from '@mui/material';
+
+import { SUPPORTED_CHAINS, HTTP_URL_PATTERN } from './const';
+import { NodeFormDialogProps } from './types';
+
+/**
+ * Add / edit dialog for a single RPC node. Mirrors the backend DTO: a chain
+ * (one of the supported ids), an http(s) URL, and an enabled flag.
+ */
+export const NodeFormDialog = ({
+  open,
+  chainId,
+  node,
+  saving,
+  onClose,
+  onSubmit,
+}: NodeFormDialogProps) => {
+  const isEdit = node !== null;
+
+  const [chain, setChain] = useState(chainId);
+  const [url, setUrl] = useState('');
+  const [enabled, setEnabled] = useState(true);
+  const [touched, setTouched] = useState(false);
+
+  // Re-seed the form whenever the dialog (re)opens for a different node/chain.
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    setChain(node ? node.chainId : chainId);
+    setUrl(node ? node.url : '');
+    setEnabled(node ? node.enabled : true);
+    setTouched(false);
+  }, [open, node, chainId]);
+
+  const urlError = touched && !HTTP_URL_PATTERN.test(url.trim());
+
+  const handleSubmit = () => {
+    setTouched(true);
+    if (!HTTP_URL_PATTERN.test(url.trim())) {
+      return;
+    }
+    onSubmit({ chainId: chain, url: url.trim(), enabled });
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>{isEdit ? 'Edit RPC node' : 'Add RPC node'}</DialogTitle>
+      <DialogContent>
+        <Stack spacing={3} sx={{ mt: 1 }}>
+          <FormControl fullWidth>
+            <InputLabel id="node-chain-label">Chain</InputLabel>
+            <Select
+              labelId="node-chain-label"
+              label="Chain"
+              value={chain}
+              onChange={(e) => setChain(Number(e.target.value))}
+            >
+              {SUPPORTED_CHAINS.map((c) => (
+                <MenuItem key={c.id} value={c.id}>
+                  {c.label} ({c.id})
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <TextField
+            fullWidth
+            autoFocus
+            label="RPC URL"
+            placeholder="https://..."
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            onBlur={() => setTouched(true)}
+            error={urlError}
+            helperText={
+              urlError ? 'Enter a valid http(s) URL' : 'Full JSON-RPC endpoint, including https://'
+            }
+          />
+
+          <FormControlLabel
+            control={<Switch checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />}
+            label="Enabled (served to the frontend)"
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose} disabled={saving}>
+          Cancel
+        </Button>
+        <Button variant="contained" onClick={handleSubmit} disabled={saving}>
+          {isEdit ? 'Save changes' : 'Add node'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/src/components/ethereum-nodes-manager/node-form-dialog.tsx
+++ b/src/components/ethereum-nodes-manager/node-form-dialog.tsx
@@ -59,7 +59,7 @@ export const NodeFormDialog = ({
   };
 
   return (
-    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+    <Dialog open={open} onClose={saving ? undefined : onClose} fullWidth maxWidth="sm">
       <DialogTitle>{isEdit ? 'Edit RPC node' : 'Add RPC node'}</DialogTitle>
       <DialogContent>
         <Stack spacing={3} sx={{ mt: 1 }}>

--- a/src/components/ethereum-nodes-manager/node-row.tsx
+++ b/src/components/ethereum-nodes-manager/node-row.tsx
@@ -1,0 +1,110 @@
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { Box, IconButton, Switch, Tooltip, Typography, useTheme } from '@mui/material';
+import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+
+import { HealthChip } from './health-chip';
+import { NodeRowProps } from './types';
+
+/**
+ * A single draggable RPC node. The drag handle is isolated to the grip icon so
+ * the action buttons and the enabled switch stay clickable.
+ */
+export const NodeRow = ({ node, position, onToggleEnabled, onEdit, onDelete }: NodeRowProps) => {
+  const theme = useTheme();
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: node.id,
+  });
+
+  return (
+    <Box
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1.5,
+        px: 1.5,
+        py: 1,
+        borderRadius: 1,
+        border: '1px solid',
+        borderColor: 'divider',
+        bgcolor: isDragging ? 'action.selected' : 'background.paper',
+        boxShadow: isDragging ? theme.shadows[6] : 'none',
+        opacity: node.enabled ? 1 : 0.55,
+        zIndex: isDragging ? 1 : 'auto',
+      }}
+    >
+      <Tooltip title="Drag to reorder priority">
+        <IconButton
+          size="small"
+          disableRipple
+          sx={{ cursor: 'grab', touchAction: 'none', color: 'text.disabled' }}
+          {...attributes}
+          {...listeners}
+        >
+          <DragIndicatorIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
+
+      <Typography
+        variant="caption"
+        sx={{
+          width: 22,
+          textAlign: 'center',
+          color: 'text.secondary',
+          fontVariantNumeric: 'tabular-nums',
+        }}
+      >
+        {position}
+      </Typography>
+
+      <Typography
+        sx={{
+          flex: 1,
+          minWidth: 0,
+          fontFamily: 'monospace',
+          fontSize: 13,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+        title={node.url}
+      >
+        {node.url}
+      </Typography>
+
+      <HealthChip
+        status={node.status}
+        lastCheckedAt={node.lastCheckedAt}
+        downSince={node.downSince}
+      />
+
+      <Tooltip
+        title={
+          node.enabled ? 'Enabled — served to the frontend' : 'Disabled — hidden from the frontend'
+        }
+      >
+        <Switch
+          size="small"
+          checked={node.enabled}
+          onChange={(e) => onToggleEnabled(node, e.target.checked)}
+        />
+      </Tooltip>
+
+      <Tooltip title="Edit node">
+        <IconButton size="small" onClick={() => onEdit(node)}>
+          <EditIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
+
+      <Tooltip title="Delete node">
+        <IconButton size="small" color="error" onClick={() => onDelete(node)}>
+          <DeleteOutlineIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
+    </Box>
+  );
+};

--- a/src/components/ethereum-nodes-manager/node-row.tsx
+++ b/src/components/ethereum-nodes-manager/node-row.tsx
@@ -12,7 +12,14 @@ import { NodeRowProps } from './types';
  * A single draggable RPC node. The drag handle is isolated to the grip icon so
  * the action buttons and the enabled switch stay clickable.
  */
-export const NodeRow = ({ node, position, onToggleEnabled, onEdit, onDelete }: NodeRowProps) => {
+export const NodeRow = ({
+  node,
+  position,
+  onToggleEnabled,
+  onEdit,
+  onDelete,
+  disabled,
+}: NodeRowProps) => {
   const theme = useTheme();
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: node.id,
@@ -41,7 +48,12 @@ export const NodeRow = ({ node, position, onToggleEnabled, onEdit, onDelete }: N
         <IconButton
           size="small"
           disableRipple
-          sx={{ cursor: 'grab', touchAction: 'none', color: 'text.disabled' }}
+          disabled={disabled}
+          sx={{
+            cursor: disabled ? 'not-allowed' : 'grab',
+            touchAction: 'none',
+            color: 'text.disabled',
+          }}
           {...attributes}
           {...listeners}
         >
@@ -91,17 +103,18 @@ export const NodeRow = ({ node, position, onToggleEnabled, onEdit, onDelete }: N
           size="small"
           checked={node.enabled}
           onChange={(e) => onToggleEnabled(node, e.target.checked)}
+          disabled={disabled}
         />
       </Tooltip>
 
       <Tooltip title="Edit node">
-        <IconButton size="small" onClick={() => onEdit(node)}>
+        <IconButton size="small" onClick={() => onEdit(node)} disabled={disabled}>
           <EditIcon fontSize="small" />
         </IconButton>
       </Tooltip>
 
       <Tooltip title="Delete node">
-        <IconButton size="small" color="error" onClick={() => onDelete(node)}>
+        <IconButton size="small" color="error" onClick={() => onDelete(node)} disabled={disabled}>
           <DeleteOutlineIcon fontSize="small" />
         </IconButton>
       </Tooltip>

--- a/src/components/ethereum-nodes-manager/types.ts
+++ b/src/components/ethereum-nodes-manager/types.ts
@@ -1,0 +1,50 @@
+import { EthereumNodeEntity } from '@tari-project/wxtm-bridge-backend-api';
+
+export interface ChainMeta {
+  id: number;
+  label: string;
+  /** Short caption shown under the chain label. */
+  caption: string;
+  /** Theme palette colour used for the chain's accent dot. */
+  color: string;
+}
+
+export interface ChainGroupProps {
+  chainId: number;
+  label: string;
+  caption: string;
+  color: string;
+  /** Nodes for this chain, already sorted by priority (sortOrder asc). */
+  nodes: EthereumNodeEntity[];
+  onReorder: (chainId: number, orderedIds: number[]) => void;
+  onToggleEnabled: (node: EthereumNodeEntity, enabled: boolean) => void;
+  onEdit: (node: EthereumNodeEntity) => void;
+  onDelete: (node: EthereumNodeEntity) => void;
+  onAdd: (chainId: number) => void;
+}
+
+export interface NodeRowProps {
+  node: EthereumNodeEntity;
+  /** 1-based priority position shown to the operator. */
+  position: number;
+  onToggleEnabled: (node: EthereumNodeEntity, enabled: boolean) => void;
+  onEdit: (node: EthereumNodeEntity) => void;
+  onDelete: (node: EthereumNodeEntity) => void;
+}
+
+export interface HealthChipProps {
+  status: EthereumNodeEntity.status;
+  lastCheckedAt: string | null;
+  downSince: string | null;
+}
+
+export interface NodeFormDialogProps {
+  open: boolean;
+  /** Pre-selected chain when adding; ignored when editing (uses the node's chain). */
+  chainId: number;
+  /** The node being edited, or null when adding a new one. */
+  node: EthereumNodeEntity | null;
+  saving: boolean;
+  onClose: () => void;
+  onSubmit: (values: { chainId: number; url: string; enabled: boolean }) => void;
+}

--- a/src/components/ethereum-nodes-manager/types.ts
+++ b/src/components/ethereum-nodes-manager/types.ts
@@ -21,6 +21,7 @@ export interface ChainGroupProps {
   onEdit: (node: EthereumNodeEntity) => void;
   onDelete: (node: EthereumNodeEntity) => void;
   onAdd: (chainId: number) => void;
+  disabled?: boolean;
 }
 
 export interface NodeRowProps {
@@ -30,6 +31,7 @@ export interface NodeRowProps {
   onToggleEnabled: (node: EthereumNodeEntity, enabled: boolean) => void;
   onEdit: (node: EthereumNodeEntity) => void;
   onDelete: (node: EthereumNodeEntity) => void;
+  disabled?: boolean;
 }
 
 export interface HealthChipProps {

--- a/src/pages/settings/edit.tsx
+++ b/src/pages/settings/edit.tsx
@@ -17,6 +17,7 @@ import { Controller } from 'react-hook-form';
 
 import { ServiceStatus } from '../../providers/settings-data-provider';
 import { SettingsEntity } from '@tari-project/wxtm-bridge-backend-api';
+import { EthereumNodesManager } from '../../components/ethereum-nodes-manager';
 
 export const SettingsEdit = () => {
   const {
@@ -441,6 +442,8 @@ export const SettingsEdit = () => {
             />
           </Box>
         </Paper>
+
+        <EthereumNodesManager />
       </Box>
     </Edit>
   );

--- a/src/providers/ethereum-nodes-data-provider.ts
+++ b/src/providers/ethereum-nodes-data-provider.ts
@@ -1,0 +1,65 @@
+import {
+  CreateParams,
+  CreateResponse,
+  DataProvider,
+  DeleteOneParams,
+  DeleteOneResponse,
+  GetListResponse,
+  UpdateParams,
+  UpdateResponse,
+} from '@refinedev/core';
+import {
+  CreateEthereumNodeReqDTO,
+  EthereumNodeEntity,
+  EthereumNodesService,
+  UpdateEthereumNodeReqDTO,
+} from '@tari-project/wxtm-bridge-backend-api';
+
+/**
+ * Read/write data provider for the bridge backend's `/ethereum-nodes` endpoint.
+ *
+ * Unlike the wrap/unwrap resources, this endpoint is a plain Nest controller that
+ * returns a bare array (no nestjsx-crud pagination envelope), so it can't go through
+ * `customNestjsxCrudDataProvider`. We wrap the generated `EthereumNodesService`
+ * directly — same approach as `settingsDataProvider`. Auth is carried by the global
+ * `OpenAPI.TOKEN` set in `useAuthProvider`.
+ */
+export const ethereumNodesDataProvider: DataProvider = {
+  getList: async <TData = EthereumNodeEntity>(): Promise<GetListResponse<TData>> => {
+    const nodes = await EthereumNodesService.getNodes();
+    return {
+      data: nodes as TData[],
+      total: nodes.length,
+    };
+  },
+
+  create: async <TData = EthereumNodeEntity, TVariables = CreateEthereumNodeReqDTO>({
+    variables,
+  }: CreateParams<TVariables>): Promise<CreateResponse<TData>> => {
+    const node = await EthereumNodesService.createNode(variables as CreateEthereumNodeReqDTO);
+    return { data: node as TData };
+  },
+
+  update: async <TData = EthereumNodeEntity, TVariables = UpdateEthereumNodeReqDTO>({
+    id,
+    variables,
+  }: UpdateParams<TVariables>): Promise<UpdateResponse<TData>> => {
+    await EthereumNodesService.updateNode(Number(id), variables as UpdateEthereumNodeReqDTO);
+    return { data: { id } as TData };
+  },
+
+  deleteOne: async <TData = EthereumNodeEntity, TVariables = unknown>({
+    id,
+  }: DeleteOneParams<TVariables>): Promise<DeleteOneResponse<TData>> => {
+    await EthereumNodesService.deleteNode(Number(id));
+    return { data: { id } as TData };
+  },
+
+  getOne: async () => {
+    throw new Error('getOne is not implemented in ethereumNodesDataProvider');
+  },
+
+  getApiUrl: () => {
+    throw new Error('getApiUrl is not implemented in ethereumNodesDataProvider');
+  },
+};

--- a/src/providers/ethereum-nodes-data-provider.ts
+++ b/src/providers/ethereum-nodes-data-provider.ts
@@ -45,7 +45,7 @@ export const ethereumNodesDataProvider: DataProvider = {
     variables,
   }: UpdateParams<TVariables>): Promise<UpdateResponse<TData>> => {
     await EthereumNodesService.updateNode(Number(id), variables as UpdateEthereumNodeReqDTO);
-    return { data: { id } as TData };
+    return { data: { id, ...variables } as TData };
   },
 
   deleteOne: async <TData = EthereumNodeEntity, TVariables = unknown>({


### PR DESCRIPTION
Description
---

Adds an "Ethereum RPC Nodes" section to the Settings page where operators can manage the public Ethereum endpoints the bridge frontend uses to talk to the blockchain. Nodes are grouped by network (Mainnet, Sepolia, Base Sepolia) and
you can:

- Add, edit, and delete nodes
- Turn each node on or off
- Drag nodes to set their priority order (the top one is used first, the rest are fallbacks)
- See a live health indicator (up / down / unknown) for each node

Every change saves immediately.

<img width="1898" height="825" alt="Screenshot 2026-06-09 at 11 34 20" src="https://github.com/user-attachments/assets/fddf64f5-a225-4e54-bb43-d91645fdd8a3" />


Motivation and Context
---

The frontend currently relies on a hard-coded public Ethereum endpoint that has been unreliable for months, with no way to change it without a code release. This lets the team manage and reorder endpoints on the fly, and add backups,
so a single broken provider no longer takes the bridge offline.

How Has This Been Tested?
---

- Linting, type checks, build, and the test suite all pass
- Verified the section loads, and that adding, editing, toggling, reordering, and deleting nodes work against the backend

What process can a PR reviewer use to test or verify this change?
---

1. Open the **Settings** page and scroll to **Ethereum RPC Nodes**
2. Click **Add node**, pick a network, enter an endpoint URL, and save
3. Toggle a node on/off and confirm the change sticks after a refresh
4. Drag two nodes to reorder them and confirm the new order persists
5. Edit a node's URL, then delete it and confirm it's removed
6. Check that the health indicator and "last checked" tooltip display

Breaking Changes
---

- [x] None
- [ ] Requires data directory to be deleted
- [ ] Other - Please specify
